### PR TITLE
Make elm make non-interactive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export PATH := $(NPM_PATH):$(PATH)
 
 all: $(ELM_FILES)
-	@elm make src/Main.elm --output dist/main.js
+	@elm make src/Main.elm --output dist/main.js --yes
 
 # TODO:
 # analyse: deps

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export PATH := $(NPM_PATH):$(PATH)
 
 all: $(ELM_FILES)
-	@elm make src/Main.elm --output dist/main.js --yes
+	@yes | elm make src/Main.elm --output dist/main.js
 
 # TODO:
 # analyse: deps


### PR DESCRIPTION
* Easier on CI.
* Easier for developers that want to get the Elm app running without
  being bothered by confirmations prompts such as
  "Some new packages are needed. Here is the upgrade plan.".